### PR TITLE
stop ci on push

### DIFF
--- a/.github/workflows/biome_check.yml
+++ b/.github/workflows/biome_check.yml
@@ -1,7 +1,6 @@
 name: Code quality
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
running biome every time a commit is pushed is wasting resource